### PR TITLE
All states

### DIFF
--- a/__tests__/get-state.ts
+++ b/__tests__/get-state.ts
@@ -16,4 +16,12 @@ describe("getState", (): void => {
       expect.arrayContaining(["Surulere", "Itire-Ikate"])
     );
   });
+
+  test("returns an object of type <IState>", (): void => {
+    expect(getState(testState)).toStrictEqual(expect.objectContaining({
+      name: expect.any(String),
+      areas: expect.any(Array),
+      geoPol: expect.any(String)
+    }))
+  });
 });

--- a/__tests__/get-states.ts
+++ b/__tests__/get-states.ts
@@ -10,9 +10,19 @@ describe("getStates", (): void => {
     expect(getStates().length).toEqual(37);
   });
 
-  test("contains randomly selected Nigerian states", (): void => {
-    expect(getStates()).toEqual(
-      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "Abuja"])
+  test("returns an array containing randomly selected Nigerian states", (): void => {
+    expect(getStates().map(s=>s.name)).toEqual(
+      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "FCT-Abuja"])
     );
+  });
+
+  test("returns an array with every object having <IState> members", (): void => {
+    getStates().forEach((s) => {
+      expect(s).toStrictEqual(expect.objectContaining({
+        name: expect.any(String),
+        areas: expect.any(Array),
+        geoPol: expect.any(String)
+      }))
+    })
   });
 });

--- a/__tests__/get-states.ts
+++ b/__tests__/get-states.ts
@@ -5,14 +5,14 @@ describe("getStates", (): void => {
     expect(typeof getStates).toEqual("function");
   });
 
-  test("returns an array with 37 items", (): void => {
+  test("returns an array of 37 items", (): void => {
     expect(Array.isArray(getStates())).toEqual(true);
     expect(getStates().length).toEqual(37);
   });
 
   test("contains randomly selected Nigerian states", (): void => {
-    expect(getStates()).toEqual(
-      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "Abuja"])
+    expect(getStates().map((s) => s.name)).toEqual(
+      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "FCT-Abuja"])
     );
   });
 });

--- a/__tests__/get-states.ts
+++ b/__tests__/get-states.ts
@@ -5,14 +5,14 @@ describe("getStates", (): void => {
     expect(typeof getStates).toEqual("function");
   });
 
-  test("returns an array of 37 items", (): void => {
+  test("returns an array with 37 items", (): void => {
     expect(Array.isArray(getStates())).toEqual(true);
     expect(getStates().length).toEqual(37);
   });
 
   test("contains randomly selected Nigerian states", (): void => {
-    expect(getStates().map((s) => s.name)).toEqual(
-      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "FCT-Abuja"])
+    expect(getStates()).toEqual(
+      expect.arrayContaining(["Lagos", "Benue", "Kebbi", "Yobe", "Abuja"])
     );
   });
 });

--- a/src/data/all.json
+++ b/src/data/all.json
@@ -1,127 +1,127 @@
 [
   {
     "name": "Abia",
-    "geoPol": "South East",
+    "geoPol":"South East",
     "areas": []
   },
   {
     "name": "Adamawa",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Akwa Ibom",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "Anambra",
-    "geoPol": "South East",
+    "geoPol":"South East",
     "areas": []
   },
   {
     "name": "Bauchi",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Bayelsa",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "Benue",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Borno",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Cross River",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "Delta",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "Ebonyi",
-    "geoPol": "South East",
+    "geoPol":"South East",
     "areas": []
   },
   {
     "name": "Edo",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "FCT-Abuja",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Ekiti",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": []
   },
   {
     "name": "Enugu",
-    "geoPol": "South East",
+    "geoPol":"South East",
     "areas": []
   },
   {
     "name": "Gombe",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Imo",
-    "geoPol": "South East",
+    "geoPol":"South East",
     "areas": []
   },
   {
     "name": "Jigawa",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Kaduna",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Kano",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Katsina",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Kebbi",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Kogi",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Kwara",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Lagos",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": [
       {
         "name": "Surulere",
@@ -169,62 +169,62 @@
   },
   {
     "name": "Nassarawa",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Niger",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Ogun",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": []
   },
   {
     "name": "Ondo",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": []
   },
   {
     "name": "Osun",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": []
   },
   {
     "name": "Oyo",
-    "geoPol": "South West",
+    "geoPol":"South West",
     "areas": []
   },
   {
     "name": "Plateau",
-    "geoPol": "North Central",
+    "geoPol":"North Central",
     "areas": []
   },
   {
     "name": "Rivers",
-    "geoPol": "South South",
+    "geoPol":"South South",
     "areas": []
   },
   {
     "name": "Sokoto",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   },
   {
     "name": "Taraba",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Yobe",
-    "geoPol": "North East",
+    "geoPol":"North East",
     "areas": []
   },
   {
     "name": "Zamfara",
-    "geoPol": "North West",
+    "geoPol":"North West",
     "areas": []
   }
 ]

--- a/src/data/all.json
+++ b/src/data/all.json
@@ -1,102 +1,127 @@
 [
   {
     "name": "Abia",
+    "geoPol": "South East",
     "areas": []
   },
   {
     "name": "Adamawa",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Akwa Ibom",
+    "geoPol": "South South",
     "areas": []
   },
   {
     "name": "Anambra",
+    "geoPol": "South East",
     "areas": []
   },
   {
     "name": "Bauchi",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Bayelsa",
+    "geoPol": "South South",
     "areas": []
   },
   {
     "name": "Benue",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Borno",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Cross River",
+    "geoPol": "South South",
     "areas": []
   },
   {
     "name": "Delta",
+    "geoPol": "South South",
     "areas": []
   },
   {
     "name": "Ebonyi",
+    "geoPol": "South East",
     "areas": []
   },
   {
     "name": "Edo",
+    "geoPol": "South South",
+    "areas": []
+  },
+  {
+    "name": "FCT-Abuja",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Ekiti",
+    "geoPol": "South West",
     "areas": []
   },
   {
     "name": "Enugu",
-    "areas": []
-  },
-  {
-    "name": "Abuja",
+    "geoPol": "South East",
     "areas": []
   },
   {
     "name": "Gombe",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Imo",
+    "geoPol": "South East",
     "areas": []
   },
   {
     "name": "Jigawa",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Kaduna",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Kano",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Katsina",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Kebbi",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Kogi",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Kwara",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Lagos",
+    "geoPol": "South West",
     "areas": [
       {
         "name": "Surulere",
@@ -144,50 +169,62 @@
   },
   {
     "name": "Nassarawa",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Niger",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Ogun",
+    "geoPol": "South West",
     "areas": []
   },
   {
     "name": "Ondo",
+    "geoPol": "South West",
     "areas": []
   },
   {
     "name": "Osun",
+    "geoPol": "South West",
     "areas": []
   },
   {
     "name": "Oyo",
+    "geoPol": "South West",
     "areas": []
   },
   {
     "name": "Plateau",
+    "geoPol": "North Central",
     "areas": []
   },
   {
     "name": "Rivers",
+    "geoPol": "South South",
     "areas": []
   },
   {
     "name": "Sokoto",
+    "geoPol": "North West",
     "areas": []
   },
   {
     "name": "Taraba",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Yobe",
+    "geoPol": "North East",
     "areas": []
   },
   {
     "name": "Zamfara",
+    "geoPol": "North West",
     "areas": []
   }
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-"use strict";
 export { getStates, getState } from "./ng-streets";

--- a/src/ng-streets.ts
+++ b/src/ng-streets.ts
@@ -2,25 +2,15 @@ import data from "./data/all.json";
 import { IState } from "./utils";
 
 /**
- * Returns an array of the contained of every state in Nigeria
- * @returns {Array<IState>}   an array containing the `name`, `areas` and `geoPol` of every state
+ * Returns an array of the name of every state in Nigeria
+ * @returns {Array}   an array containing the name of every state in Nigeria
  */
-const getStates = (): Array<IState> => {name
-  return [
-    ...data.sort((s1, s2) => {
-      if (s1.name.toLowerCase() < s2.name.toLowerCase()) {
-        return -1;
-      }
-      if (s1.name.toLowerCase() > s2.name.toLowerCase()) {
-        return 1;
-      }
-      return 0;
-    }),
-  ];
+const getStates = (): Array<string> => {
+  return data.map((state: { name: string }) => state.name);
 };
 
 /**
- * Returns the name, geoPol and areas data of a state
+ * Returns the name and areas data of a state
  * @param {string}  name - the name of the state
  * @returns {IState}   an object containing the name and areas data of a state
  */

--- a/src/ng-streets.ts
+++ b/src/ng-streets.ts
@@ -2,53 +2,30 @@ import data from "./data/all.json";
 import { IState } from "./utils";
 
 /**
- * Returns an array of the name of every state in Nigeria
- * @returns {Array}   an array containing the name of every state in Nigeria
+ * Returns an array of the contained of every state in Nigeria
+ * @returns {Array<IState>}   an array containing the `name`, `areas` and `geoPol` of every state
  */
-const getStates = (): Array<string> => {
-  return data.map((state: { name: string }) => state.name);
+const getStates = (): Array<IState> => {name
+  return [
+    ...data.sort((s1, s2) => {
+      if (s1.name.toLowerCase() < s2.name.toLowerCase()) {
+        return -1;
+      }
+      if (s1.name.toLowerCase() > s2.name.toLowerCase()) {
+        return 1;
+      }
+      return 0;
+    }),
+  ];
 };
 
 /**
- * Returns the name and areas data of a state
+ * Returns the name, geoPol and areas data of a state
  * @param {string}  name - the name of the state
  * @returns {IState}   an object containing the name and areas data of a state
  */
 const getState = (name: string): IState | undefined => {
   return data.find((state) => state.name.toLowerCase() === name.toLowerCase());
 };
-
-// /**
-//  * Returns the data (name, streets) of every area in a state
-//  * @param {string}  stateName - the name of the state
-//  * @returns {Array<IArea>} an array containing the name of each area in `stateName`
-//  */
-// const getAreas = (stateName: string): Array<IArea> | undefined => {
-//   const state = data.find(
-//     (state) => state.name.toLowerCase() === stateName.toLowerCase()
-//   );
-//   if (state === undefined) return undefined;
-//   return state.areas.map((area) => area);
-// };
-
-// /**
-//  * Returns data of an area in a state
-//  * @param {string}  stateName - the name of the state
-//  * @returns {Array<IArea>} an array containing the name of each area in `stateName`
-//  */
-// const getArea = (areaName: string): IArea | undefined => {
-//   return undefined
-// };
-
-// /**
-//  * Returns the name of every street in an area
-//  * @param {string}  area - the name of the state
-//  * @returns {Array<string>} an array containing the name of each street in `area`
-//  */
-// const getStreets = (area: string): Array<string> | undefined => {
-//   const state = data.find((state) => state.name === stateName);
-//   if (state === undefined) return undefined;
-//   return state.areas.map((area) => area["name"]);
-// };
 
 export { getStates, getState };

--- a/src/ng-streets.ts
+++ b/src/ng-streets.ts
@@ -2,15 +2,25 @@ import data from "./data/all.json";
 import { IState } from "./utils";
 
 /**
- * Returns an array of the name of every state in Nigeria
- * @returns {Array}   an array containing the name of every state in Nigeria
+ * Returns an array of the contained of every state in Nigeria
+ * @returns {Array<IState>}   an array containing the `name`, `areas` and `geoPol` of every state
  */
-const getStates = (): Array<string> => {
-  return data.map((state: { name: string }) => state.name);
+const getStates = (): Array<IState> => {name
+  return [
+    ...data.sort((s1, s2) => {
+      if (s1.name.toLowerCase() < s2.name.toLowerCase()) {
+        return -1;
+      }
+      if (s1.name.toLowerCase() > s2.name.toLowerCase()) {
+        return 1;
+      }
+      return 0;
+    }),
+  ];
 };
 
 /**
- * Returns the name and areas data of a state
+ * Returns the name, geoPol and areas data of a state
  * @param {string}  name - the name of the state
  * @returns {IState}   an object containing the name and areas data of a state
  */

--- a/src/utils/IState.ts
+++ b/src/utils/IState.ts
@@ -2,5 +2,6 @@ import { IArea } from "./IArea";
 
 export interface IState {
   name: string;
+  geoPol: string;
   areas: Array<IArea>;
 }


### PR DESCRIPTION
The return value of `getStates` is changed. `getStates` now returns all data
of all states, not only the names.

Note: This change is a major. It requires a bump in the major version number